### PR TITLE
feat: add exclude option to config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
-        "@basketry/sorbet": "^0.0.14",
+        "@basketry/sorbet": "github:justworkshr/basketry-sorbet",
         "basketry": "^0.0.25",
         "case": "^1.6.3",
         "pluralize": "^8.0.0",
@@ -558,19 +558,19 @@
       }
     },
     "node_modules/@basketry/sorbet": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@basketry/sorbet/-/sorbet-0.0.14.tgz",
-      "integrity": "sha512-1AdTfJPhmOLMc0O8cf5XDqLdRY1q/29WXkzl8Sy7mv60oEvrnfEzl6o6vzBsEKKOOUgwegEjw0OSRRDh0YEZDw==",
+      "version": "0.0.22",
+      "resolved": "git+ssh://git@github.com/justworkshr/basketry-sorbet.git#fe6a1f9bb173297c7f546e3fa27cc9a65c0e666e",
+      "license": "MIT",
       "dependencies": {
-        "basketry": "^0.0.24",
+        "basketry": "^0.0.32",
         "case": "^1.6.3",
         "prettier": "^2.5.1"
       }
     },
     "node_modules/@basketry/sorbet/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -597,11 +597,12 @@
       }
     },
     "node_modules/@basketry/sorbet/node_modules/basketry": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/basketry/-/basketry-0.0.24.tgz",
-      "integrity": "sha512-JEcH+olZLfj2PaWUdsZN5bN7cIKB7A25l9dByZUHX78qRAKX2yYVUZb/juB+i1RyYsX+f9MuME4OzBlHOHb7bw==",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/basketry/-/basketry-0.0.32.tgz",
+      "integrity": "sha512-CEHbjTBjSKfjhagUGqwofrU7emxY8Qwe2nx3tb6EbClcrhkXaZUt98kgC0ouAKhOxTFe1L92t2N6eJ2lHACsvQ==",
       "dependencies": {
         "ajv": "^8.11.0",
+        "case": "^1.6.3",
         "chalk": "^4.1.2",
         "ts-node": "^10.7.0",
         "webpack-merge": "^5.8.0",
@@ -609,6 +610,9 @@
       },
       "bin": {
         "basketry": "lib/cli.js"
+      },
+      "funding": {
+        "url": "https://github.com/basketry/basketry?sponsor=1"
       }
     },
     "node_modules/@basketry/sorbet/node_modules/chalk": {
@@ -624,6 +628,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@basketry/sorbet/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@basketry/sorbet/node_modules/color-convert": {
@@ -667,26 +684,26 @@
       }
     },
     "node_modules/@basketry/sorbet/node_modules/yargs": {
-      "version": "17.5.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@basketry/sorbet/node_modules/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
         "node": ">=12"
       }
@@ -8618,19 +8635,18 @@
       }
     },
     "@basketry/sorbet": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@basketry/sorbet/-/sorbet-0.0.14.tgz",
-      "integrity": "sha512-1AdTfJPhmOLMc0O8cf5XDqLdRY1q/29WXkzl8Sy7mv60oEvrnfEzl6o6vzBsEKKOOUgwegEjw0OSRRDh0YEZDw==",
+      "version": "git+ssh://git@github.com/justworkshr/basketry-sorbet.git#fe6a1f9bb173297c7f546e3fa27cc9a65c0e666e",
+      "from": "@basketry/sorbet@github:justworkshr/basketry-sorbet",
       "requires": {
-        "basketry": "^0.0.24",
+        "basketry": "^0.0.32",
         "case": "^1.6.3",
         "prettier": "^2.5.1"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -8647,11 +8663,12 @@
           }
         },
         "basketry": {
-          "version": "0.0.24",
-          "resolved": "https://registry.npmjs.org/basketry/-/basketry-0.0.24.tgz",
-          "integrity": "sha512-JEcH+olZLfj2PaWUdsZN5bN7cIKB7A25l9dByZUHX78qRAKX2yYVUZb/juB+i1RyYsX+f9MuME4OzBlHOHb7bw==",
+          "version": "0.0.32",
+          "resolved": "https://registry.npmjs.org/basketry/-/basketry-0.0.32.tgz",
+          "integrity": "sha512-CEHbjTBjSKfjhagUGqwofrU7emxY8Qwe2nx3tb6EbClcrhkXaZUt98kgC0ouAKhOxTFe1L92t2N6eJ2lHACsvQ==",
           "requires": {
             "ajv": "^8.11.0",
+            "case": "^1.6.3",
             "chalk": "^4.1.2",
             "ts-node": "^10.7.0",
             "webpack-merge": "^5.8.0",
@@ -8665,6 +8682,16 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
@@ -8699,23 +8726,23 @@
           }
         },
         "yargs": {
-          "version": "17.5.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
-          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
-            "cliui": "^7.0.2",
+            "cliui": "^8.0.1",
             "escalade": "^3.1.1",
             "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
             "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
+            "yargs-parser": "^21.1.1"
           }
         },
         "yargs-parser": {
-          "version": "21.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "fix:prettier": "prettier -w .",
     "clean:coverage": "rimraf coverage",
     "pretest": "run-s -s clean",
-    "prepack": "run-s -s build"
+    "prepack": "run-s -s build",
+    "prepare": "npm run build"
   },
   "keywords": [],
   "author": "Steve Konves",
@@ -49,7 +50,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@basketry/sorbet": "^0.0.14",
+    "@basketry/sorbet": "github:justworkshr/basketry-sorbet",
     "basketry": "^0.0.25",
     "case": "^1.6.3",
     "pluralize": "^8.0.0",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,4 @@
+export enum RailsFileTypes {
+  BaseControllerInterface = 'BaseControllerInterface',
+  ServiceController = 'ServiceController',
+}

--- a/src/router-factory.test.ts
+++ b/src/router-factory.test.ts
@@ -28,4 +28,85 @@ describe('InterfaceFactory', () => {
       expect(file.contents).toStrictEqual(snapshot);
     }
   });
+
+  describe('when the BaseControllerInterface is excluded', () => {
+    it('does not generate the BaseControllerInterface file', () => {
+      // ARRANGE
+      const service = require('basketry/lib/example-ir.json');
+
+      // ACT
+      const files = generateTypes(service, {
+        sorbet: {
+          typesModule: 'types',
+          enumsModule: 'enums',
+        },
+        basketry: {
+          exclude: ['BaseControllerInterface'],
+        },
+      });
+
+      // ASSERT
+      files.forEach((file) => {
+        expect(file.path).not.toEqual(
+          expect.arrayContaining(['base_controller_interface.rb']),
+        );
+      });
+    });
+  });
+
+  // when the ServiceController is excluded, it does not generate the ServiceController file
+  describe('when the ServiceController is excluded', () => {
+    it('does not generate the ServiceController file', () => {
+      // ARRANGE
+      const service = require('basketry/lib/example-ir.json');
+
+      // ACT
+      const files = generateTypes(service, {
+        sorbet: {
+          typesModule: 'types',
+          enumsModule: 'enums',
+        },
+        basketry: {
+          exclude: ['ServiceController'],
+        },
+      });
+
+      // ASSERT
+      files.forEach((file) => {
+        expect(file.path[file.path.length - 1].endsWith('_controller.rb')).toBe(
+          false,
+        );
+      });
+    });
+  });
+
+  // when both the ServiceController and the BaseControllerInterface are excluded,
+  // it does not generate the ServiceController file or the BaseControllerInterface file
+  describe('when both the ServiceController and the BaseControllerInterface are excluded', () => {
+    it('does not generate the ServiceController file or the BaseControllerInterface file', () => {
+      // ARRANGE
+      const service = require('basketry/lib/example-ir.json');
+
+      // ACT
+      const files = generateTypes(service, {
+        sorbet: {
+          typesModule: 'types',
+          enumsModule: 'enums',
+        },
+        basketry: {
+          exclude: ['ServiceController', 'BaseControllerInterface'],
+        },
+      });
+
+      // ASSERT
+      files.forEach((file) => {
+        expect(file.path).not.toEqual(
+          expect.arrayContaining(['base_controller_interface.rb']),
+        );
+        expect(file.path[file.path.length - 1].endsWith('_controller.rb')).toBe(
+          false,
+        );
+      });
+    });
+  });
 });

--- a/src/router-factory.ts
+++ b/src/router-factory.ts
@@ -32,6 +32,7 @@ import {
 } from '@basketry/sorbet/lib/name-factory';
 import { warning } from '@basketry/sorbet/lib/warning';
 import { RailsOptions } from './types';
+import { RailsFileTypes } from './enums';
 
 export const generateTypes: Generator = (service, options?: RailsOptions) => {
   return new Builder(service, options).build();
@@ -47,13 +48,30 @@ class Builder {
   private readonly castPrimitiveArray = new Set<Primitive>();
 
   build(): File[] {
+    const includeServiceController = !this.options?.basketry?.exclude?.includes(
+      RailsFileTypes.ServiceController,
+    );
+    const includeBaseControllerInterface =
+      !this.options?.basketry?.exclude?.includes(
+        RailsFileTypes.BaseControllerInterface,
+      );
+
     return [
       this.buildRouterFile(),
-      ...this.service.interfaces.map((int) => this.buildControllerFile(int)),
+      ...(includeServiceController
+        ? [
+            ...this.service.interfaces.map((int) =>
+              this.buildControllerFile(int),
+            ),
+          ]
+        : []),
       this.buildHelperFile(),
-      this.buildBaseControllerInterfaceFile(),
+      ...(includeBaseControllerInterface
+        ? [this.buildBaseControllerInterfaceFile()]
+        : []),
     ];
   }
+
   private buildRouterFile(): File {
     return {
       path: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
-import { SorbetOptions } from '@basketry/sorbet/lib/types';
+import { BasketryOptions, SorbetOptions } from '@basketry/sorbet/lib/types';
 
 export type RailsOptions = {
   sorbet?: SorbetOptions & {
     baseController?: string;
   };
+  basketry?: BasketryOptions;
 };


### PR DESCRIPTION
This PR implements an `exclude` option for the basketry/rails config.

- [x] when the `BaseControllerInterface` string is supplied to the `options` array, the generators exclude the `base_controller_interface.rb` file in the build
- [x] when the `ServiceController` string is supplied to the `options` array, the generators exclude the `*_controller.rb` files in the build